### PR TITLE
Update installer for multilanguage

### DIFF
--- a/installer/windows/NSIS/setup.nsi
+++ b/installer/windows/NSIS/setup.nsi
@@ -123,10 +123,19 @@ FunctionEnd
   
 ;--------------------------------
 ;Languages
- 
-    !insertmacro MUI_LANGUAGE "English"
-    !insertmacro MUI_LANGUAGE "Italian"
+; reference: https://nsis.sourceforge.io/Examples/Modern%20UI/MultiLanguage.nsi
 
+    !insertmacro MUI_LANGUAGE "English"
+    !insertmacro MUI_LANGUAGE "Arabic"
+    !insertmacro MUI_LANGUAGE "SimpChinese"    
+    !insertmacro MUI_LANGUAGE "French"
+    !insertmacro MUI_LANGUAGE "German"
+    !insertmacro MUI_LANGUAGE "Korean"
+    !insertmacro MUI_LANGUAGE "Italian"
+    !insertmacro MUI_LANGUAGE "Portuguese"
+    !insertmacro MUI_LANGUAGE "PortugueseBR"
+    !insertmacro MUI_LANGUAGE "Russian"
+    !insertmacro MUI_LANGUAGE "Spanish"
 
 ;--------------------------------
 ;Installer Sections

--- a/installer/windows/NSIS/setup.nsi
+++ b/installer/windows/NSIS/setup.nsi
@@ -125,6 +125,8 @@ FunctionEnd
 ;Languages
  
     !insertmacro MUI_LANGUAGE "English"
+    !insertmacro MUI_LANGUAGE "Italian"
+
 
 ;--------------------------------
 ;Installer Sections
@@ -156,7 +158,7 @@ Section "Start Menu Shortcut" SectionStartMenuShortcut
     ;Create shortcuts in the start menu programs directory
     CreateDirectory "$SMPROGRAMS\DownZemAll"
     CreateShortCut "$SMPROGRAMS\DownZemAll\DownZemAll.lnk" "$INSTDIR\DownZemAll.exe"
-    CreateShortCut "$SMPROGRAMS\DownZemAll\Uninstall DownZemAll.lnk" "$INSTDIR\Uninstall.exe"
+    CreateShortCut "$SMPROGRAMS\DownZemAll\$(DESC_UninstallIconDescription).lnk" "$INSTDIR\Uninstall.exe"
 
 SectionEnd
 
@@ -172,10 +174,20 @@ SectionEnd
 ;Descriptions
 
     ;Language strings
+
+    ; Language strings (English)
     LangString DESC_SectionMainApplication ${LANG_ENGLISH} "The main application."
     LangString DESC_SectionLauncher ${LANG_ENGLISH} "The launcher, used for messaging with web browser."
     LangString DESC_SectionStartMenuShortcut ${LANG_ENGLISH} "Create Start Menu Shortcut."
     LangString DESC_SectionDesktopShortcut ${LANG_ENGLISH} "Create Desktop Shortcut."
+    LangString DESC_UninstallIconDescription ${LANG_ENGLISH} "Uninstall DownZemAll"
+
+    ; Language strings (Italian)
+    LangString DESC_SectionMainApplication ${LANG_ITALIAN} "Applicazione principale."
+    LangString DESC_SectionLauncher ${LANG_ITALIAN} "Il launcher, usato per i messaggi con il browser web."
+    LangString DESC_SectionStartMenuShortcut ${LANG_ITALIAN} "Crea gruppo programmi nel menu Start."
+    LangString DESC_SectionDesktopShortcut ${LANG_ITALIAN} "Crea collegamento programma sul desktop."
+    LangString DESC_UninstallIconDescription ${LANG_ITALIAN} "Disinstalla DownZemAll"
 
     ;Assign language strings to sections
     !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN


### PR DESCRIPTION
@setvisible 

Add info for Italian NSIS language
Add strings for italian
Make string "Uninstall DownZemAllL" in program group multilanguage

Using the same scheme it's possible to add other languages.

Please check and merge,

Please modify teh source to include currently language files for Italian.

Please rebuild the installer including Italian language.

Then I wil, test it,.

Then please contact other translator (ex. French/German/Portoguese (Brasilian)/Spanish) to include relative strings into the installer.

Thanks.
