### PR TITLE
Fix missing Title Bar icon on KDE Plasma Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,6 +80,9 @@ int main(int argc, char *argv[])
 
     parser.process(application);
 
+    // Fix missing Title Bar icon on KDE Plasma's Wayland session.
+    application.setDesktopFileName("downzemall");
+
 #ifndef QT_DEBUG
     if (parser.isSet(verboseOption)) {
         qInstallMessageHandler(releaseVerboseMessageHandler);


### PR DESCRIPTION
Before this patch there is just the generic Wayland icon in the title bar instead of the DownZemAll icon.

Before:
![image](https://github.com/setvisible/DownZemAll/assets/11980981/c126bcc0-3fff-462f-9c45-fcc085b3346b)

After:
![image](https://github.com/setvisible/DownZemAll/assets/11980981/e46a9893-fe67-4c5b-962b-3dfa09cc7443)
