### PR TITLE
Fix build with Qt 6.6.x (fixes #120)

### DIFF
--- a/src/core/mimedatabase.h
+++ b/src/core/mimedatabase.h
@@ -20,6 +20,7 @@
 
 #include <QtCore/QString>
 #include <QtCore/QStringList>
+#include <QtCore/QUrl>
 #include <QtGui/QPixmap>
 
 constexpr int default_icon_size = 32;


### PR DESCRIPTION
FreeBSD is in the process of updating Qt to 6.6.0 and we are seeing the same build error as in #120.

FreeBSD bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=275068
Build log: https://pkg-status.freebsd.org/package22/data/132amd64-default-foo/2023-11-18_08h04m12s/logs/errors/downzemall-3.0.6_1.log